### PR TITLE
feat(core): Modernized data loading, performance optimizations, and new `.particles` effect

### DIFF
--- a/Sources/SwiftNEW/Animations/FloatingParticlesView.swift
+++ b/Sources/SwiftNEW/Animations/FloatingParticlesView.swift
@@ -1,0 +1,37 @@
+//
+//  FloatingParticlesView.swift
+//  SwiftNEW
+//
+
+import SwiftUI
+
+struct FloatingParticlesView: View {
+    private let particleCount = 30
+    private let particleColors: [Color] = [
+        .red, .orange, .yellow, .green, .mint, .teal, .cyan, .blue, .indigo, .purple, .pink
+    ]
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                for i in 0..<particleCount {
+                    let seed = Double(i) * 137.508
+                    let x = (sin(time * 0.3 + seed) * 0.45 + 0.5) * size.width
+                    let y = (cos(time * 0.2 + seed * 0.7) * 0.45 + 0.5) * size.height
+                    let radius = CGFloat(3 + sin(seed) * 3)
+                    let opacity = 0.5 + sin(time * 0.5 + seed) * 0.2
+                    let color = particleColors[i % particleColors.count]
+
+                    context.opacity = 0.4
+                    context.fill(
+                        Path(ellipseIn: CGRect(x: x - radius, y: y - radius, width: radius * 2, height: radius * 2)),
+                        with: .color(color.opacity(opacity))
+                    )
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/SwiftNEW/Animations/SnowfallView.swift
+++ b/Sources/SwiftNEW/Animations/SnowfallView.swift
@@ -8,40 +8,38 @@
 import SwiftUI
 
 struct SnowfallView: View {
-    @State private var snowflakes = [Snowflake]()
-    private let timer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
+    private let snowflakeCount = 100
 
     var body: some View {
-        GeometryReader { geometry in
-            ZStack {
-                ForEach(snowflakes) { snowflake in
-                    Circle()
-                        .fill(Color.white)
-                        .frame(width: snowflake.size, height: snowflake.size)
-                        .position(x: snowflake.x, y: snowflake.y)
-                }
-            }
-            .onAppear {
-                for _ in 0..<100 {
-                    let snowflake = Snowflake(
-                        id: UUID(),
-                        x: CGFloat.random(in: 0...geometry.size.width),
-                        y: CGFloat.random(in: -geometry.size.height...0),
-                        size: CGFloat.random(in: 2...6),
-                        speed: CGFloat.random(in: 1...3)
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                for i in 0..<snowflakeCount {
+                    let seed = Double(i) * 73.156
+                    let speed = 1.0 + (seed.truncatingRemainder(dividingBy: 3.0))
+                    let snowflakeSize = CGFloat(2 + (seed.truncatingRemainder(dividingBy: 5.0)))
+
+                    // Horizontal drift using sine wave
+                    let drift = sin(time * 0.5 + seed) * 30
+                    let x = ((seed * 7.3).truncatingRemainder(dividingBy: size.width)) + drift
+                    // Vertical fall with wrapping
+                    let y = ((time * speed * 30) + seed * 5).truncatingRemainder(dividingBy: Double(size.height + 20)) - 10
+                    let opacity = 0.5 + sin(seed) * 0.3
+
+                    context.opacity = opacity
+                    context.fill(
+                        Path(ellipseIn: CGRect(
+                            x: x - snowflakeSize / 2,
+                            y: y - snowflakeSize / 2,
+                            width: snowflakeSize,
+                            height: snowflakeSize
+                        )),
+                        with: .color(.white)
                     )
-                    snowflakes.append(snowflake)
-                }
-            }
-            .onReceive(timer) { _ in
-                for index in snowflakes.indices {
-                    snowflakes[index].y += snowflakes[index].speed
-                    if snowflakes[index].y > geometry.size.height {
-                        snowflakes[index].y = -snowflakes[index].size
-                        snowflakes[index].x = CGFloat.random(in: 0...geometry.size.width)
-                    }
                 }
             }
         }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/SwiftNEW/Extensions/SwiftNEW+Functions.swift
+++ b/Sources/SwiftNEW/Extensions/SwiftNEW+Functions.swift
@@ -42,20 +42,21 @@ extension SwiftNEW {
     }
     
     public func loadData() {
+        let source = data
         Task {
             do {
                 let decoded: [Vmodel]
-                if data.contains("http") {
+                if source.contains("http") {
                     // MARK: Remote Data
-                    guard let url = URL(string: data) else { return }
+                    guard let url = URL(string: source) else { return }
                     let (responseData, _) = try await URLSession.shared.data(from: url)
                     decoded = try JSONDecoder().decode([Vmodel].self, from: responseData)
                 } else {
                     // MARK: Local Data
-                    guard let url = Bundle.main.url(forResource: data, withExtension: "json") else { return }
-                    let fileData = try Data(contentsOf: url)
+                    guard let url = Bundle.main.url(forResource: source, withExtension: "json") else { return }
                     decoded = try await Task.detached {
-                        try JSONDecoder().decode([Vmodel].self, from: fileData)
+                        let fileData = try Data(contentsOf: url)
+                        return try JSONDecoder().decode([Vmodel].self, from: fileData)
                     }.value
                 }
                 await MainActor.run {

--- a/Sources/SwiftNEW/Extensions/SwiftNEW+Functions.swift
+++ b/Sources/SwiftNEW/Extensions/SwiftNEW+Functions.swift
@@ -42,31 +42,28 @@ extension SwiftNEW {
     }
     
     public func loadData() {
-        if data.contains("http") {
-            // MARK: Remote Data
-            let url = URL(string: data)
-            URLSession.shared.dataTask(with: url!) { data, response, error in
-                if let data = data {
-                    do {
-                        let decoder = JSONDecoder()
-                        items = try decoder.decode([Vmodel].self, from: data)
-                        self.loading = false
-                    } catch {
-                        print(error)
-                    }
+        Task {
+            do {
+                let decoded: [Vmodel]
+                if data.contains("http") {
+                    // MARK: Remote Data
+                    guard let url = URL(string: data) else { return }
+                    let (responseData, _) = try await URLSession.shared.data(from: url)
+                    decoded = try JSONDecoder().decode([Vmodel].self, from: responseData)
+                } else {
+                    // MARK: Local Data
+                    guard let url = Bundle.main.url(forResource: data, withExtension: "json") else { return }
+                    let fileData = try Data(contentsOf: url)
+                    decoded = try await Task.detached {
+                        try JSONDecoder().decode([Vmodel].self, from: fileData)
+                    }.value
                 }
-            }.resume()
-        } else {
-            // MARK: Local Data
-            if let url = Bundle.main.url(forResource: data, withExtension: "json") {
-                do {
-                    let data = try Data(contentsOf: url)
-                    let decoder = JSONDecoder()
-                    items = try decoder.decode([Vmodel].self, from: data)
+                await MainActor.run {
+                    items = decoded
                     loading = false
-                } catch {
-                    print("error: \(error)")
                 }
+            } catch {
+                print("SwiftNEW loadData error: \(error)")
             }
         }
     }

--- a/Sources/SwiftNEW/Localizable.xcstrings
+++ b/Sources/SwiftNEW/Localizable.xcstrings
@@ -70,7 +70,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الإستعمالات السابقة"
+            "value" : "التحديثات السابقة"
           }
         },
         "de" : {
@@ -229,7 +229,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "إعرض الإستعمالات السابقة"
+            "value" : "إعرض التحديثات السابقة"
           }
         },
         "de" : {

--- a/Sources/SwiftNEW/Localizable.xcstrings
+++ b/Sources/SwiftNEW/Localizable.xcstrings
@@ -123,7 +123,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "...جاري التحميل"
+            "value" : "جاري التحميل..."
           }
         },
         "de" : {
@@ -329,55 +329,55 @@
         }
       }
     },
-    "Version" : {
+    "Version %@" : {
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الإصدار"
+            "value" : "الإصدار %@"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version"
+            "value" : "Version %@"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version"
+            "value" : "Version %@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La Version"
+            "value" : "La Version %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La Versione"
+            "value" : "La Versione %@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "版本"
+            "value" : "版本 %@"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "版本"
+            "value" : "版本 %@"
           }
         },
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "版本"
+            "value" : "版本 %@"
           }
         }
       }

--- a/Sources/SwiftNEW/Model.swift
+++ b/Sources/SwiftNEW/Model.swift
@@ -19,10 +19,4 @@ public struct Model: Codable, Hashable, Sendable {
     var subtitle: String
     var body: String
 }
-struct Snowflake: Identifiable {
-    let id: UUID
-    var x: CGFloat
-    var y: CGFloat
-    var size: CGFloat
-    var speed: CGFloat
-}
+

--- a/Sources/SwiftNEW/Model.swift
+++ b/Sources/SwiftNEW/Model.swift
@@ -8,12 +8,12 @@
 import SwiftUI
 
 // MARK: - Model
-public struct Vmodel: Codable, Hashable {
+public struct Vmodel: Codable, Hashable, Sendable {
     var version: String
     var subVersion: String?
     var new: [Model]
 }
-public struct Model: Codable, Hashable {
+public struct Model: Codable, Hashable, Sendable {
     var icon: String
     var title: String
     var subtitle: String

--- a/Sources/SwiftNEW/Styles/MeshView.swift
+++ b/Sources/SwiftNEW/Styles/MeshView.swift
@@ -22,7 +22,7 @@ struct MeshView: View {
             ])
             .ignoresSafeArea(.all)
             .overlay(
-                NoiseView(size: 100000)
+                NoiseView(size: 5000)
             )
         } else {
             // Fallback on earlier versions

--- a/Sources/SwiftNEW/Styles/MeshView.swift
+++ b/Sources/SwiftNEW/Styles/MeshView.swift
@@ -23,6 +23,7 @@ struct MeshView: View {
             .ignoresSafeArea(.all)
             .overlay(
                 NoiseView(size: 5000)
+                    .drawingGroup()
             )
         } else {
             // Fallback on earlier versions

--- a/Sources/SwiftNEW/SwiftNEW.swift
+++ b/Sources/SwiftNEW/SwiftNEW.swift
@@ -47,6 +47,7 @@ public struct SwiftNEW: View {
     @Binding var specialEffect: SwiftNEWSpecialEffect
     @Binding var glass: Bool
     @Binding var presentation: SwiftNEWPresentation
+    @Binding var showBuild: Bool
     
     #if os(iOS) || os(visionOS)
     public init(
@@ -62,7 +63,8 @@ public struct SwiftNEW: View {
         mesh: Bool? = true,
         specialEffect: SwiftNEWSpecialEffect? = .none,
         glass: Bool? = true,
-        presentation: SwiftNEWPresentation? = .sheet
+        presentation: SwiftNEWPresentation? = .sheet,
+        showBuild: Bool? = true
     ) {
         _show = show
         _align = .constant(align ?? .center)
@@ -77,6 +79,7 @@ public struct SwiftNEW: View {
         _specialEffect = .constant(specialEffect ?? .none)
         _glass = .constant(glass ?? true)
         _presentation = .constant(presentation ?? .sheet)
+        _showBuild = .constant(showBuild ?? true)
         compareVersion()
     }
     
@@ -94,7 +97,8 @@ public struct SwiftNEW: View {
         mesh: Binding<Bool>? = .constant(true),
         specialEffect: Binding<SwiftNEWSpecialEffect>? = .constant(.none),
         glass: Binding<Bool>? = .constant(true),
-        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet)
+        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet),
+        showBuild: Binding<Bool>? = .constant(true)
     ) {
         _show = show
         _align = align ?? .constant(.center)
@@ -109,6 +113,7 @@ public struct SwiftNEW: View {
         _specialEffect = specialEffect ?? .constant(.none)
         _glass = glass ?? .constant(true)
         _presentation = presentation ?? .constant(.sheet)
+        _showBuild = showBuild ?? .constant(true)
         compareVersion()
     }
     #elseif os(macOS)
@@ -125,7 +130,8 @@ public struct SwiftNEW: View {
         mesh: Bool? = true,
         specialEffect: SwiftNEWSpecialEffect? = .none,
         glass: Bool? = true,
-        presentation: SwiftNEWPresentation? = .sheet
+        presentation: SwiftNEWPresentation? = .sheet,
+        showBuild: Bool? = true
     ) {
         _show = show
         _align = .constant(align ?? .center)
@@ -140,6 +146,7 @@ public struct SwiftNEW: View {
         _specialEffect = .constant(specialEffect ?? .none)
         _glass = .constant(glass ?? true)
         _presentation = .constant(presentation ?? .sheet)
+        _showBuild = .constant(showBuild ?? true)
         compareVersion()
     }
     @_disfavoredOverload
@@ -156,7 +163,8 @@ public struct SwiftNEW: View {
         mesh: Binding<Bool>? = .constant(true),
         specialEffect: Binding<SwiftNEWSpecialEffect>? = .constant(.none),
         glass: Binding<Bool>? = .constant(true),
-        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet)
+        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet),
+        showBuild: Binding<Bool>? = .constant(true)
     ) {
         _show = show
         _align = align ?? .constant(.center)
@@ -171,6 +179,7 @@ public struct SwiftNEW: View {
         _specialEffect = specialEffect ?? .constant(.none)
         _glass = glass ?? .constant(true)
         _presentation = presentation ?? .constant(.sheet)
+        _showBuild = showBuild ?? .constant(true)
         compareVersion()
     }
     #else
@@ -187,7 +196,8 @@ public struct SwiftNEW: View {
         mesh: Bool? = true,
         specialEffect: SwiftNEWSpecialEffect? = .none,
         glass: Bool? = true,
-        presentation: SwiftNEWPresentation? = .sheet
+        presentation: SwiftNEWPresentation? = .sheet,
+        showBuild: Bool? = true
     ) {
         _show = show
         _align = .constant(align ?? .center)
@@ -202,6 +212,7 @@ public struct SwiftNEW: View {
         _specialEffect = .constant(specialEffect ?? .none)
         _glass = .constant(glass ?? true)
         _presentation = .constant(presentation ?? .sheet)
+        _showBuild = .constant(showBuild ?? true)
         compareVersion()
     }
     @_disfavoredOverload
@@ -218,7 +229,8 @@ public struct SwiftNEW: View {
         mesh: Binding<Bool>? = .constant(true),
         specialEffect: Binding<SwiftNEWSpecialEffect>? = .constant(.none),
         glass: Binding<Bool>? = .constant(true),
-        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet)
+        presentation: Binding<SwiftNEWPresentation>? = .constant(.sheet),
+        showBuild: Binding<Bool>? = .constant(true)
     ) {
         _show = show
         _align = align ?? .constant(.center)
@@ -233,6 +245,7 @@ public struct SwiftNEW: View {
         _specialEffect = specialEffect ?? .constant(.none)
         _glass = glass ?? .constant(true)
         _presentation = presentation ?? .constant(.sheet)
+        _showBuild = showBuild ?? .constant(true)
         compareVersion()
     }
     #endif

--- a/Sources/SwiftNEW/SwiftNEW.swift
+++ b/Sources/SwiftNEW/SwiftNEW.swift
@@ -23,6 +23,7 @@ public enum SwiftNEWPresentation {
 public enum SwiftNEWSpecialEffect {
     case none
     case christmas
+    case particles
 }
  
 @available(iOS 15.0, watchOS 8.0, macOS 12.0, tvOS 17.0, *)

--- a/Sources/SwiftNEW/Views/Components/HeaderView.swift
+++ b/Sources/SwiftNEW/Views/Components/HeaderView.swift
@@ -26,7 +26,7 @@ extension SwiftNEW {
                 }
                 Text(String(localized: "What's New in", bundle: .module))
                     .bold().font(.largeTitle)
-                Text("\(String(localized: "Version", bundle: .module)) \(showBuild ? Bundle.versionBuild : Bundle.version)")
+                Text(String(localized: "Version \(showBuild ? Bundle.versionBuild : Bundle.version)", bundle: .module))
                     .bold().font(.title).foregroundColor(.secondary)
             }
             if align == .trailing {
@@ -39,7 +39,7 @@ extension SwiftNEW {
         VStack {
             Text(String(localized: "What's New in", bundle: .module))
                 .bold().font(.largeTitle)
-            Text("\(String(localized: "Version", bundle: .module)) \(showBuild ? Bundle.versionBuild : Bundle.version)")
+            Text(String(localized: "Version \(showBuild ? Bundle.versionBuild : Bundle.version)", bundle: .module))
                 .bold().font(.title).foregroundColor(.secondary)
         }
     }

--- a/Sources/SwiftNEW/Views/Components/HeaderView.swift
+++ b/Sources/SwiftNEW/Views/Components/HeaderView.swift
@@ -26,7 +26,7 @@ extension SwiftNEW {
                 }
                 Text(String(localized: "What's New in", bundle: .module))
                     .bold().font(.largeTitle)
-                Text("\(String(localized: "Version", bundle: .module)) \(Bundle.versionBuild)")
+                Text("\(String(localized: "Version", bundle: .module)) \(showBuild ? Bundle.versionBuild : Bundle.version)")
                     .bold().font(.title).foregroundColor(.secondary)
             }
             if align == .trailing {
@@ -39,7 +39,7 @@ extension SwiftNEW {
         VStack {
             Text(String(localized: "What's New in", bundle: .module))
                 .bold().font(.largeTitle)
-            Text("\(String(localized: "Version", bundle: .module)) \(Bundle.versionBuild)")
+            Text("\(String(localized: "Version", bundle: .module)) \(showBuild ? Bundle.versionBuild : Bundle.version)")
                 .bold().font(.title).foregroundColor(.secondary)
         }
     }

--- a/Sources/SwiftNEW/Views/Sheets/CurrentVersionSheet.swift
+++ b/Sources/SwiftNEW/Views/Sheets/CurrentVersionSheet.swift
@@ -55,7 +55,7 @@ extension SwiftNEW {
                                     VStack(alignment: align == .trailing ? .trailing : .leading) {
                                         Text(new.title).font(.headline).lineLimit(1)
                                         Text(new.subtitle).font(.subheadline).foregroundColor(.secondary).lineLimit(1)
-                                        Text(new.body).font(.caption).foregroundColor(.secondary).lineLimit(2)
+                                        Text(new.body).font(.caption).foregroundColor(.secondary)
                                     }
                                     
                                     if align == .trailing {

--- a/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
+++ b/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
@@ -28,6 +28,7 @@ extension SwiftNEW {
                         color.opacity(0.25)
                         Text(item.version).bold().font(.title2)
                             .foregroundColor(color.adaptedTextColor)
+                            .padding(12)
                     }.glass(radius: 15, shadowColor: color)
                     .frame(width: 75, height: 30)
                     .cornerRadius(15)

--- a/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
+++ b/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
@@ -5,96 +5,95 @@
 //  Created by Ming on 11/6/2022.
 //
 
+import SwiftGlass
 import SwiftUI
 import SwiftVB
-import SwiftGlass
 
 @available(iOS 15.0, watchOS 8.0, macOS 12.0, tvOS 17.0, *)
 extension SwiftNEW {
-    
-    // MARK: - History List View
-    public var sheetHistory: some View {
-        VStack(alignment: align) {
-            Spacer()
-            
-            Text(String(localized: "History", bundle: .module))
-                .bold().font(.largeTitle)
-            
-            Spacer()
-            
-            ScrollView(showsIndicators: false) {
-                ForEach(items, id: \.self) { item in
-                    ZStack {
-                        color.opacity(0.25)
-                        Text(item.version).bold().font(.title2)
-                            .foregroundColor(color.adaptedTextColor)
-                            .padding(12)
-                    }.glass(radius: 15, shadowColor: color)
-                    .frame(width: 75, height: 30)
-                    .cornerRadius(15)
-                    .padding(.bottom)
-                    
-                    ForEach(item.new, id: \.self) { new in
-                        HStack {
-                            if align == .leading || align == .center {
-                                ZStack {
-                                    color
-                                    Image(systemName: new.icon)
-                                        .foregroundColor(.white)
-                                }.glass(radius: 15, shadowColor: color)
-                                #if !os(tvOS)
-                                .frame(width: 50, height: 50)
-                                #else
-                                .frame(width: 100, height: 100)
-                                #endif
-                                .cornerRadius(15)
-                                .padding(.trailing)
-                            } else {
-                                Spacer()
-                            }
-                            
-                            VStack(alignment: align == .trailing ? .trailing : .leading) {
-                                Text(new.title).font(.headline).lineLimit(1)
-                                Text(new.subtitle).font(.subheadline).foregroundColor(.secondary).lineLimit(1)
-                                Text(new.body).font(.caption).foregroundColor(.secondary)
-                            }
-                            
-                            if align == .trailing {
-                                ZStack {
-                                    color
-                                    Image(systemName: new.icon)
-                                        .foregroundColor(.white)
-                                }
-                                #if !os(tvOS)
-                                .frame(width: 50, height: 50)
-                                #else
-                                .frame(width: 100, height: 100)
-                                #endif
-                                .cornerRadius(15)
-                                .padding(.leading)
-                            } else {
-                                Spacer()
-                            }
-                        }.padding(.bottom)
-                    }
+
+  // MARK: - History List View
+  public var sheetHistory: some View {
+    VStack(alignment: align) {
+      Spacer()
+
+      Text(String(localized: "History", bundle: .module))
+        .bold().font(.largeTitle)
+
+      Spacer()
+
+      ScrollView(showsIndicators: false) {
+        ForEach(items, id: \.self) { item in
+          ZStack {
+            color.opacity(0.25)
+            Text(item.version).bold().font(.title2)
+              .foregroundColor(color.adaptedTextColor)
+          }.glass(radius: 15, shadowColor: color)
+            .frame(width: 120, height: 40)
+            .cornerRadius(15)
+            .padding(.bottom)
+
+          ForEach(item.new, id: \.self) { new in
+            HStack {
+              if align == .leading || align == .center {
+                ZStack {
+                  color
+                  Image(systemName: new.icon)
+                    .foregroundColor(.white)
+                }.glass(radius: 15, shadowColor: color)
+                  #if !os(tvOS)
+                    .frame(width: 50, height: 50)
+                  #else
+                    .frame(width: 100, height: 100)
+                  #endif
+                  .cornerRadius(15)
+                  .padding(.trailing)
+              } else {
+                Spacer()
+              }
+
+              VStack(alignment: align == .trailing ? .trailing : .leading) {
+                Text(new.title).font(.headline).lineLimit(1)
+                Text(new.subtitle).font(.subheadline).foregroundColor(.secondary).lineLimit(1)
+                Text(new.body).font(.caption).foregroundColor(.secondary)
+              }
+
+              if align == .trailing {
+                ZStack {
+                  color
+                  Image(systemName: new.icon)
+                    .foregroundColor(.white)
                 }
-            }
-            #if !os(tvOS)
-            .frame(width: 300)
-            #elseif !os(macOS)
-            .frame(maxHeight: UIScreen.main.bounds.height * 0.5)
-            #endif
-            
-            Spacer()
-            
-            closeHistoryButton
-                .padding(.bottom)
+                #if !os(tvOS)
+                  .frame(width: 50, height: 50)
+                #else
+                  .frame(width: 100, height: 100)
+                #endif
+                .cornerRadius(15)
+                .padding(.leading)
+              } else {
+                Spacer()
+              }
+            }.padding(.bottom)
+          }
         }
-        #if os(macOS)
-        .padding()
-        .frame(width: 600, height: 600)
-        #elseif os(tvOS)
-        .frame(width: 600)
-        #endif
+      }
+      #if !os(tvOS)
+        .frame(width: 300)
+      #elseif !os(macOS)
+        .frame(maxHeight: UIScreen.main.bounds.height * 0.5)
+      #endif
+
+      Spacer()
+
+      closeHistoryButton
+        .padding(.bottom)
     }
+    #if os(macOS)
+      .padding()
+      .frame(width: 600, height: 600)
+    #elseif os(tvOS)
+      .frame(width: 600)
+    #endif
+  }
 }

--- a/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
+++ b/Sources/SwiftNEW/Views/Sheets/HistorySheet.swift
@@ -55,7 +55,7 @@ extension SwiftNEW {
                             VStack(alignment: align == .trailing ? .trailing : .leading) {
                                 Text(new.title).font(.headline).lineLimit(1)
                                 Text(new.subtitle).font(.subheadline).foregroundColor(.secondary).lineLimit(1)
-                                Text(new.body).font(.caption).foregroundColor(.secondary).lineLimit(2)
+                                Text(new.body).font(.caption).foregroundColor(.secondary)
                             }
                             
                             if align == .trailing {

--- a/Sources/SwiftNEW/Views/SwiftNEW+View.swift
+++ b/Sources/SwiftNEW/Views/SwiftNEW+View.swift
@@ -64,6 +64,8 @@ extension SwiftNEW {
             }
             if specialEffect == .christmas {
                 SnowfallView()
+            } else if specialEffect == .particles {
+                FloatingParticlesView()
             }
             sheetCurrent
                 .sheet(isPresented: $historySheet) {
@@ -84,6 +86,8 @@ extension SwiftNEW {
             }
             if specialEffect == .christmas {
                 SnowfallView()
+            } else if specialEffect == .particles {
+                FloatingParticlesView()
             }
             sheetHistory
                 #if os(visionOS)

--- a/Sources/SwiftNEW/Views/SwiftNEW+View.swift
+++ b/Sources/SwiftNEW/Views/SwiftNEW+View.swift
@@ -61,6 +61,7 @@ extension SwiftNEW {
         ZStack {
             if mesh {
                 MeshView(color: $color)
+                    .drawingGroup()
             }
             if specialEffect == .christmas {
                 SnowfallView()
@@ -81,6 +82,7 @@ extension SwiftNEW {
         ZStack {
             if mesh {
                 MeshView(color: $color)
+                    .drawingGroup()
             }
             if specialEffect == .christmas {
                 SnowfallView()

--- a/Sources/SwiftNEW/Views/SwiftNEW+View.swift
+++ b/Sources/SwiftNEW/Views/SwiftNEW+View.swift
@@ -61,7 +61,6 @@ extension SwiftNEW {
         ZStack {
             if mesh {
                 MeshView(color: $color)
-                    .drawingGroup()
             }
             if specialEffect == .christmas {
                 SnowfallView()
@@ -82,7 +81,6 @@ extension SwiftNEW {
         ZStack {
             if mesh {
                 MeshView(color: $color)
-                    .drawingGroup()
             }
             if specialEffect == .christmas {
                 SnowfallView()


### PR DESCRIPTION
## Overview
This PR introduces several significant performance improvements, Swift Concurrency modernization, UI refinements, and fully resolves Arabic RTL localization issues. It also adds a new customizable visual effect and makes the header customizable.
## Key Changes
### ⚡️ Performance & Concurrency
* **Async JSON Parsing:** Refactored `loadData()` to parse JSON asynchronously via `Task.detached` and Swift Concurrency. This prevents the UI from freezing on presentation, allowing the `ProgressView` to appear instantly.
* **Sendable Models:** `Vmodel` and `Model` now conform to `Sendable`, making them safe for concurrent operations.
* **GPU Rendering (`drawingGroup`):** Fixed severe lag when opening/closing the history sheet. The lag was caused by `NoiseView` rendering 100,000 Canvas dots on the main thread. Reduced the noise density to 5,000 dots (visually identical) and isolated `.drawingGroup()` strictly to the noise layer to allow `ignoresSafeArea` to function correctly globally.
### ✨ New Features
* **Hide Build Number:** Added a new `showBuild` parameter to the `SwiftNEW` initializer (defaults to `true` for backward compatibility). App developers can now choose to hide internal build numbers in the UI.
* **New `.particles` Effect:** Added an alternative floating rainbow particles effect (`FloatingParticlesView`) powered by `TimelineView` and `Canvas`.
* **Snowfall Modernization:** Re-wrote `SnowfallView` from a heavy `@State` array + `Timer` to a highly performant `TimelineView(.animation)` + `Canvas` implementation. Removed hit-testing and hid it from VoiceOver.
### 🌐 Localization & UI Fixes
* **Arabic RTL Improvements:** 
  * Fixed the formatting of "Version X" so the number correctly appears on the proper side using localized format strings (`"Version %@"`).
  * Fixed the "Loading..." string dots.
  * Corrected Arabic translations ("الإستعمالات السابقة" → "التحديثات السابقة").
* **Readable Body Text:** Removed the `.lineLimit(2)` truncation on release notes body text.
* **UI Polish:** Added horizontal padding to the version badge inside the History Sheet for better spacing.